### PR TITLE
Some fixes suggested by luacheck.

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -55,7 +55,7 @@ local function repl()
         stream:seek("set", position)
         print("Unexpected input: "..stream:read("*all*"))
       else
-        local ok, result = pcall(compiler.eval, form)
+        local _, result = pcall(compiler.eval, form)
         print("=", result)
       end
     end

--- a/itertools.lua
+++ b/itertools.lua
@@ -162,7 +162,7 @@ list = setmetatable({
 }, {__call = function(self, t)
     local orig = setmetatable({}, list)
     local last = orig
-    local maxn = table.maxn or function(t) return #t end
+    local maxn = table.maxn or function(tb) return #tb end
     for i=1, maxn(t) do
       last[2] = setmetatable({t[i], nil}, list)
       last = last[2]
@@ -246,6 +246,5 @@ return {
   resolve=resolve,
   bind=bind,
   contains=contains,
-  last=last,
   slice=slice
 }

--- a/reader.lua
+++ b/reader.lua
@@ -171,7 +171,7 @@ local function read_right_bracket(stream, byte)
   raise(UnmatchedRightBracketException(stream))
 end
 
-local function read_string(stream, byte)
+local function read_string(stream)
   local str, byte = "", ""
   local escaped = false
   repeat
@@ -241,7 +241,7 @@ local function read_vector(stream, byte)
         rightbracket = true
       end,
       [EOFException] = function(Exception)
-        raise(UnmatchedLeftBracketException(stream, position))
+        raise(UnmatchedLeftBracketException(stream))
       end
     }))
     for i=1, count, 2 do
@@ -264,7 +264,7 @@ local function read_table(stream, byte)
         rightbrace = true
       end,
       [EOFException] = function(Exception)
-        raise(UnmatchedLeftBraceException(stream, position))
+        raise(UnmatchedLeftBraceException(stream))
       end
     }))
     for i=1, count, 2 do
@@ -323,23 +323,33 @@ local function read_list(stream, byte)
   end)
 end
 
-local function read_table_quote(stream, byte)
+local function read_table_quote(stream)
   return pair({symbol('table-quote'), list({read(stream)})})
 end
 
-local function read_quote(stream, byte)
+local function read_quote(stream)
   return pair({symbol('quote'), list({read(stream)})})
 end
 
-local function read_quasiquote(stream, byte)
+local function read_quasiquote(stream)
   return pair({symbol('quasiquote'), list({read(stream)})})
 end
 
-local function read_quasiquote_eval(stream, byte)
+local function read_quasiquote_eval(stream)
   return pair({symbol('quasiquote-eval'), list({read(stream)})})
 end
 
-local function read_dispatch_macro(stream, byte)
+local function read_negative(stream)
+  local byte = stream:read(1)
+  stream:seek("cur", -1)
+  if not byte:match(" ") then
+    return pair({symbol('-'), list({read(stream)})})
+  else
+    return symbol('-')
+  end
+end
+
+local function read_dispatch_macro(stream)
   local byte = stream:read(1)
   if not byte then
     raise(EOFException(stream:seek("cur", -1) and stream))
@@ -356,7 +366,7 @@ end
 
 -- Dispatch character table. See `read_dispatch_macro`.
 _D = {
-  ['\\'] = read_character,
+--  ['\\'] = read_character,
   ['\''] = read_table_quote,
   [' '] = read_hash_literal
 }


### PR DESCRIPTION
Add a makefile that runs luacheck with a number of warnings disabled and a set of globals to ignore. Would be nice to get rid of the rest of the warnings, but this is a nice start.