### PR TITLE
Ensure that map passes an index arg to its fn.

### DIFF
--- a/itertools.lua
+++ b/itertools.lua
@@ -188,7 +188,7 @@ local function map(f, objs, ...)
   local last = orig
   if objs ~= false then
     for i, v in ipairs(objs or {}) do
-      last[2] = pair({f(v), nil})
+      last[2] = pair({f(v, i), nil})
       last=last[2]
     end 
     return orig[2]


### PR DESCRIPTION
Crashes without this patch.