### PR TITLE
Check for _C in special G before using it.

### DIFF
--- a/compiler.lua
+++ b/compiler.lua
@@ -637,7 +637,7 @@ eval = function (obj, stream, env, G)
 
   local reference
 
-  if G ~= _G then
+  if G ~= _G and G._C then
     reference = with_C(G._C, compile, block, stream, obj, _R.position(obj))
   else
     reference = compile(block, stream, obj, _R.position(obj))


### PR DESCRIPTION
I think sandboxed code that doesn't include its own `_C` should use the default one at compile time?