### PR TITLE
Default to empty _C when sandboxing.

### DIFF
--- a/compiler.lua
+++ b/compiler.lua
@@ -637,8 +637,8 @@ eval = function (obj, stream, env, G)
 
   local reference
 
-  if G ~= _G and G._C then
-    reference = with_C(G._C, compile, block, stream, obj, _R.position(obj))
+  if G ~= _G then
+    reference = with_C(G._C or {}, compile, block, stream, obj, _R.position(obj))
   else
     reference = compile(block, stream, obj, _R.position(obj))
   end


### PR DESCRIPTION
This should isolate changes to _C from un-sandboxed code.